### PR TITLE
Fix decimal parsing and cleanup HTML

### DIFF
--- a/Projet Vizualiser carto edc15p asz/index.html
+++ b/Projet Vizualiser carto edc15p asz/index.html
@@ -6,8 +6,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="css/style.css" />
   <script src="https://cdn.jsdelivr.net/npm/chart.js" defer></script>
-  <script src="js/charts.js" defer></script>
-  <script src="js/calculs.js" defer></script>
   <script src="js/main.js" defer></script>
 </head>
 

--- a/Projet Vizualiser carto edc15p asz/js/main.js
+++ b/Projet Vizualiser carto edc15p asz/js/main.js
@@ -126,7 +126,7 @@ function updateAFR(col) {
 }
 
 function computeTIms(col) {
-  const ti = parseFloat(getInput("TIdeg", col)?.value);
+  const ti = parseFloat(getInput("TIdeg", col)?.value.replace(",", "."));
   const rpm = rpmList[col - 1];
   if (isNaN(ti)) return null;
   return (ti * 60000) / (rpm * 360);
@@ -141,8 +141,8 @@ function updateTIms(col) {
 }
 
 function computeATDC(col) {
-  const soi = parseFloat(getInput("SOI", col)?.value);
-  const ti = parseFloat(getInput("TIdeg", col)?.value);
+  const soi = parseFloat(getInput("SOI", col)?.value.replace(",", "."));
+  const ti = parseFloat(getInput("TIdeg", col)?.value.replace(",", "."));
   if (isNaN(soi) || isNaN(ti)) return null;
   return soi + ti;
 }


### PR DESCRIPTION
## Summary
- remove references to missing `charts.js` and `calculs.js`
- handle comma decimals when computing `TIms` and `ATDC`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68531b861784832aad9133a20cede70a